### PR TITLE
fix<BackendSessionComponent.akickByUid>: not async method:kickByUid.

### DIFF
--- a/packages/pinus/lib/common/remote/frontend/sessionRemote.ts
+++ b/packages/pinus/lib/common/remote/frontend/sessionRemote.ts
@@ -84,6 +84,6 @@ export class SessionRemote {
      * @param  {Function} cb     callback function
      */
     kickByUid(uid: UID, reason: string) {
-        return this.app.sessionService.kick(uid, reason);
+        return this.app.sessionService.akick(uid, reason);
     }
 }


### PR DESCRIPTION
### 报错代码 backendSessionService.akickByUid(serverId, uid, reason);
``` javascript
async kick(uid: string , serverIds: string[], reason: string) {
    if (!serverIds || !serverIds.length) {
      return true;
    }

    const backendSessionService = this.app.get('backendSessionService');
    try {
      for (const serverId of serverIds) {
        await backendSessionService.akickByUid(serverId, uid, reason);
      }
    } catch (error) {
      logger.error('remote connector.entryHandler.kick occurred an error: ', error.stack);
      return false;
    }
    return true;
  }
```

### 错误信息
```
[2018-06-01T17:05:02.234] [ERROR] rpc-logger - [connector-server-2 ] remote connector.entryHandler.kick occurred an error: Error
    at Object.pLogger.(anonymous function) [as error] (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/pinus-logger/lib/logger.ts:59:34)
    at EntryRemoter.kick (/Users/dyuxuan/pivilion/testPinus/game-server/app/servers/connector/remote/entryRemoter.ts:50:14)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7) Error: not async method:kickByUid
    at Dispatcher.route (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/pinus-rpc/lib/rpc-server/dispatcher.ts:69:16)
    at MQTTAcceptor.Gateway.acceptor.acceptorFactory [as cb] (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/pinus-rpc/lib/rpc-server/gateway.ts:46:24)
    at MQTTAcceptor.processMsg (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/pinus-rpc/lib/rpc-server/acceptors/mqtt-acceptor.ts:161:14)
    at Connection.<anonymous> (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/pinus-rpc/lib/rpc-server/acceptors/mqtt-acceptor.ts:85:30)
    at emitOne (events.js:116:13)
    at Connection.emit (events.js:211:7)
    at Connection.emitPacket (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/mqtt-connection/connection.js:10:8)
    at emitOne (events.js:116:13)
    at Connection.emit (events.js:211:7)
    at addChunk (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/readable-stream/lib/_stream_readable.js:291:12)
    at readableAddChunk (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/readable-stream/lib/_stream_readable.js:278:11)
    at Connection.Readable.push (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/readable-stream/lib/_stream_readable.js:245:10)
    at Connection.Duplexify._forward (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/duplexify/index.js:170:26)
    at DestroyableTransform.onreadable (/Users/dyuxuan/pivilion/testPinus/game-server/node_modules/duplexify/index.js:134:10)
    at emitNone (events.js:106:13)
    at DestroyableTransform.emit (events.js:208:7)
```

### 修改内容
类`SessionRemote` 方法 `kickByUid` 返回Promise 可修复此问题
