### PR TITLE
修改加载路由信息

### DIFF
--- a/packages/pinus-loader/lib/loader.ts
+++ b/packages/pinus-loader/lib/loader.ts
@@ -114,11 +114,11 @@ export function checkFileType(fn: string, suffix: string) {
     return str === suffix;
 }
 
-let isFile = function (path: string) {
+export function isFile(path: string) {
     return fs.statSync(path).isFile();
 };
 
-let isDir = function (path: string) {
+export function isDir(path: string) {
     return fs.statSync(path).isDirectory();
 };
 

--- a/packages/pinus/lib/components/dictionary.ts
+++ b/packages/pinus/lib/components/dictionary.ts
@@ -40,6 +40,37 @@ export class DictionaryComponent implements IComponent {
         let routes = [];
 
         let handlerPathss: {[serverType: string]: string[]} = {};
+        let loadHandlerPrototype = function(path: string) {
+            let files = fs.readdirSync(path);
+            if (files.length === 0) {
+                console.warn('path is empty, path:' + path);
+                return;
+            }
+
+            if (path.charAt(path.length - 1) !== '/') {
+                path += '/';
+            }
+
+            let fp, fn, m, res: {[key: string]: any} = {};
+            for (let i = 0, l = files.length; i < l; i++) {
+                fn = files[i];
+                fp = path + fn;
+                if (!Loader.isFile(fp) || !Loader.checkFileType(fn, '.js')) {
+                    // only load js file type
+                    continue;
+                }
+
+                m = Loader.loadFile(fp, false);
+                if (!m) {
+                    continue;
+                }
+                for (let key in m) {
+                    res[key] = m[key];
+                }
+            }
+
+            return res;
+        };
 
         // Load all the handler files
         for (let serverType in servers) {
@@ -58,7 +89,7 @@ export class DictionaryComponent implements IComponent {
                 continue;
             }
             for (let p of paths) {
-                let handlers = Loader.load(p, this.app, false, false, LoaderPathType.PINUS_HANDLER);
+                let handlers = loadHandlerPrototype(p);
 
                 for (let name in handlers) {
                     let handler = handlers[name];


### PR DESCRIPTION
connector类服务器通过Loader.load加载handler路由信息，存在new Handler引起的风险，该风险由Handler所写业务代码有关，建议通过导出prototype获取路由信息，因此声明Handler时必须export才能获取到。