### PR TITLE
connetor增加forwardMsg开关，当forwardMsg=false时，connector不会转发消息

### DIFF
--- a/packages/pinus/lib/components/connector.ts
+++ b/packages/pinus/lib/components/connector.ts
@@ -34,6 +34,7 @@ export interface ConnectorComponentOptions {
     blacklistFun?: BlackListFunction;
     useDict?: boolean;
     useProtobuf?: boolean;
+    forwardMsg?: boolean;
 }
 
 
@@ -60,6 +61,7 @@ export class ConnectorComponent implements IComponent {
     useAsyncCoder: boolean;
     blacklistFun: BlackListFunction;
     connection: ConnectionService;
+    forwardMsg: boolean;
 
     keys: { [id: number]: RsaKey } = {};
     blacklist: string[] = [];
@@ -76,6 +78,7 @@ export class ConnectorComponent implements IComponent {
         this.useHostFilter = opts.useHostFilter;
         this.useAsyncCoder = opts.useAsyncCoder;
         this.blacklistFun = opts.blacklistFun;
+        this.forwardMsg = opts.forwardMsg;
 
         if (opts.useDict) {
             app.load(pinus.components.dictionary, app.get('dictionaryConfig'));
@@ -418,6 +421,12 @@ export class ConnectorComponent implements IComponent {
         let type = this.checkServerType(msg.route);
         if (!type) {
             logger.error('invalid route string. route : %j', msg.route);
+            return;
+        }
+        if (type !== this.app.getServerType() && this.forwardMsg === false) {
+            logger.warn('illegal route. forwardMsg=false route=', msg.route);
+            // kick client requests for illegal route
+            this.session.kickBySessionId(session.id);
             return;
         }
         this.server.globalHandle(msg, session.toFrontendSession(), (err, resp) => {


### PR DESCRIPTION
connetor增加forwardMsg开关，当forwardMsg=false时，connector不会转发消息，只处理发给自己当前serverType的消息。其它消息视为非法消息，强行踢掉客户端。
应用场景(gate)，在示例的chat项目中，虽然独立出来一个gate服务器，但是该gate服务器与connector服务器并没有本质的区别，如果外人错误使用还是会往gate服务器上发送本应该往connector服务器上发送的消息也会占用gate的资源。
所以增加一个开关，让gate服务器只能处理发往gate的handler。任何往gate发送的game.XXXHandler.XXX的请求都视为非法请求。