### PR TITLE
protocol解包，增加类型和长度判断，缓解错误消息带来的影响。

### DIFF
--- a/packages/pinus-protocol/lib/protocol.ts
+++ b/packages/pinus-protocol/lib/protocol.ts
@@ -46,6 +46,10 @@ export namespace Package {
   export let TYPE_DATA = 4;
   export let TYPE_KICK = 5;
 
+  function isValidType(type: number): boolean {
+    return type >= TYPE_HANDSHAKE && type <= TYPE_KICK;
+  }
+
   /**
    * Package protocol encode.
    *
@@ -97,6 +101,9 @@ export namespace Package {
     while (offset < bytes.length) {
       let type = bytes[offset++];
       length = ((bytes[offset++]) << 16 | (bytes[offset++]) << 8 | bytes[offset++]) >>> 0;
+      if (!isValidType(type) || length > bytes.length) {
+        return { 'type': type }; //return invalid type, then disconnect!
+      }
       let body = length ? Buffer.alloc(length) : null;
       if (body) {
         copyArray(body, 0, bytes, offset, length);


### PR DESCRIPTION
在收到错误的消息后，不应该继续解包，直接返回错误的类型。在收到大量错误消息(攻击)时，可以降低connector的cpu开销。