### PR TITLE
解决afterStartAll不生效

### DIFF
--- a/packages/pinus/lib/application.ts
+++ b/packages/pinus/lib/application.ts
@@ -574,10 +574,12 @@ export class Application {
             if (!err) {
                 logger.info('%j finish start', id);
             }
-            appUtil.optLifecycles(self.usedPlugins, Constants.LIFECYCLE.AFTER_STARTUP, self, cb);
-            let usedTime = Date.now() - self.startTime;
-            logger.info('%j startup in %s ms', id, usedTime);
-            self.event.emit(events.START_SERVER, id);
+            appUtil.optLifecycles(self.usedPlugins, Constants.LIFECYCLE.AFTER_STARTUP, self, function (err?: Error) {
+                let usedTime = Date.now() - self.startTime;
+                logger.info('%j startup in %s ms', id, usedTime);
+                self.event.emit(events.START_SERVER, id);
+                cb && cb(err);
+            });
         });
     }
 


### PR DESCRIPTION
当afterStartup为异步调用时,需等到cb调用之后,才抛出事件，解决afterStartAll和afterStartup的顺序问题。