### PR TITLE
origin基本是Error或其它扩展过的Error对象，cloneError会导致message等其它信息丢失

### DIFF
--- a/packages/pinus-rpc/lib/rpc-server/acceptors/mqtt-acceptor.ts
+++ b/packages/pinus-rpc/lib/rpc-server/acceptors/mqtt-acceptor.ts
@@ -147,7 +147,7 @@ export class MQTTAcceptor extends EventEmitter implements IAcceptor {
     cloneError(origin: {msg: string, stack: object}) {
         // copy the stack infos for Error instance json result is empty
         let res = {
-            msg: origin.msg,
+            ...origin,
             stack: origin.stack
         };
         return res;

--- a/packages/pinus-rpc/lib/rpc-server/acceptors/mqtt2-acceptor.ts
+++ b/packages/pinus-rpc/lib/rpc-server/acceptors/mqtt2-acceptor.ts
@@ -147,7 +147,7 @@ export class MQTT2Acceptor extends EventEmitter {
   cloneError(origin: { msg: string, stack: object }) {
     // copy the stack infos for Error instance json result is empty
     let res = {
-      msg: origin.msg,
+      ...origin,
       stack: origin.stack
     };
     return res;

--- a/packages/pinus-rpc/lib/rpc-server/acceptors/tcp-acceptor.ts
+++ b/packages/pinus-rpc/lib/rpc-server/acceptors/tcp-acceptor.ts
@@ -203,7 +203,7 @@ export class TCPAcceptor extends EventEmitter implements IAcceptor {
     cloneError(origin: { msg: any, stack: any }) {
         // copy the stack infos for Error instance json result is empty
         let res = {
-            msg: origin.msg,
+            ...origin,
             stack: origin.stack
         };
         return res;

--- a/packages/pinus-rpc/lib/rpc-server/acceptors/ws-acceptor.ts
+++ b/packages/pinus-rpc/lib/rpc-server/acceptors/ws-acceptor.ts
@@ -155,7 +155,7 @@ export class WSAcceptor extends EventEmitter {
   cloneError(origin: { msg: any, stack: Error }) {
     // copy the stack infos for Error instance json result is empty
     let res = {
-      msg: origin.msg,
+      ...origin,
       stack: origin.stack
     };
     return res;

--- a/packages/pinus-rpc/lib/rpc-server/acceptors/ws2-acceptor.ts
+++ b/packages/pinus-rpc/lib/rpc-server/acceptors/ws2-acceptor.ts
@@ -168,7 +168,7 @@ export class WS2Acceptor extends EventEmitter {
   cloneError = function (origin: { msg: any, stack: Error }) {
     // copy the stack infos for Error instance json result is empty
     let res = {
-      msg: origin.msg,
+      ...origin,
       stack: origin.stack
     };
     return res;


### PR DESCRIPTION
Error对象或子对象里面都是message，不是msg，还有可能包含一些其它扩展消息，之前那样clone会导致部分信息丢失