### PR TITLE
统一跨平台下编译文件的换行符"LF"

### DIFF
--- a/examples/robot-sample/tsconfig.json
+++ b/examples/robot-sample/tsconfig.json
@@ -2,29 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": false, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": false,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/examples/robot-sample/tsconfig.json
+++ b/examples/robot-sample/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": false, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": false,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
     "outDir":"./dist",     //重定向输出目录。

--- a/examples/simple-example/game-server/tsconfig.json
+++ b/examples/simple-example/game-server/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": false, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": false,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/examples/simple-example/game-server/tsconfig.json
+++ b/examples/simple-example/game-server/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": false, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": false,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/examples/websocket-chat-ts-run/game-server/tsconfig.json
+++ b/examples/websocket-chat-ts-run/game-server/tsconfig.json
@@ -2,29 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": false, //暂时关闭在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
-    "inlineSourceMap": true,     //用于debug
+    "inlineSourceMap": true, //用于debug
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./app/**/*.ts",
     "./config/**/*.ts",
     "./app.ts",

--- a/examples/websocket-chat-ts-run/game-server/tsconfig.json
+++ b/examples/websocket-chat-ts-run/game-server/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": false, //暂时关闭在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,     //用于debug
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
     "outDir":"./dist",     //重定向输出目录。

--- a/examples/websocket-chat/game-server/tsconfig.json
+++ b/examples/websocket-chat/game-server/tsconfig.json
@@ -2,29 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
-    "inlineSourceMap": true,     //用于debug
+    "inlineSourceMap": true, //用于debug
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/examples/websocket-chat/game-server/tsconfig.json
+++ b/examples/websocket-chat/game-server/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,     //用于debug
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
     "outDir":"./dist",     //重定向输出目录。

--- a/packages/pinus-admin/tsconfig.json
+++ b/packages/pinus-admin/tsconfig.json
@@ -2,29 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-admin/tsconfig.json
+++ b/packages/pinus-admin/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
     "outDir":"./dist",     //重定向输出目录。

--- a/packages/pinus-loader/tsconfig.json
+++ b/packages/pinus-loader/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-loader/tsconfig.json
+++ b/packages/pinus-loader/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus-logger/tsconfig.json
+++ b/packages/pinus-logger/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-logger/tsconfig.json
+++ b/packages/pinus-logger/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus-monitor/tsconfig.json
+++ b/packages/pinus-monitor/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-monitor/tsconfig.json
+++ b/packages/pinus-monitor/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus-protobuf/tsconfig.json
+++ b/packages/pinus-protobuf/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-protobuf/tsconfig.json
+++ b/packages/pinus-protobuf/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus-protocol/tsconfig.json
+++ b/packages/pinus-protocol/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-protocol/tsconfig.json
+++ b/packages/pinus-protocol/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus-rpc/tsconfig.json
+++ b/packages/pinus-rpc/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-rpc/tsconfig.json
+++ b/packages/pinus-rpc/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus-scheduler/tsconfig.json
+++ b/packages/pinus-scheduler/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus-scheduler/tsconfig.json
+++ b/packages/pinus-scheduler/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus/template/game-server/tsconfig.json
+++ b/packages/pinus/template/game-server/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitAny": false, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": false,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/packages/pinus/template/game-server/tsconfig.json
+++ b/packages/pinus/template/game-server/tsconfig.json
@@ -2,31 +2,30 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "es2017",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": false, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": false,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus/tsconfig.json
+++ b/packages/pinus/tsconfig.json
@@ -2,31 +2,30 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node",
-    "mocha"
+      // add node as an option
+      "node",
+      "mocha"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/packages/pinus/tsconfig.json
+++ b/packages/pinus/tsconfig.json
@@ -16,6 +16,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/plugins/base-gate/tsconfig.json
+++ b/plugins/base-gate/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,     //用于debug
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
     "outDir":"./dist",     //重定向输出目录。

--- a/plugins/base-plugin/tsconfig.json
+++ b/plugins/base-plugin/tsconfig.json
@@ -2,29 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
-    "inlineSourceMap": true,     //用于debug
+    "inlineSourceMap": true, //用于debug
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/plugins/base-plugin/tsconfig.json
+++ b/plugins/base-plugin/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,     //用于debug
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
     "outDir":"./dist",     //重定向输出目录。

--- a/plugins/pinus-robot-plugin/tsconfig.json
+++ b/plugins/pinus-robot-plugin/tsconfig.json
@@ -2,29 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2017",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/plugins/pinus-robot-plugin/tsconfig.json
+++ b/plugins/pinus-robot-plugin/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
     "outDir":"./dist",     //重定向输出目录。

--- a/tools/pinus-cli/tsconfig.json
+++ b/tools/pinus-cli/tsconfig.json
@@ -2,30 +2,29 @@
   "compilerOptions": {
     // types option has been previously configured
     "types": [
-    // add node as an option
-    "node"
+      // add node as an option
+      "node"
     ],
-    "module": "commonjs",   //指定生成哪个模块系统代码
+    "module": "commonjs", //指定生成哪个模块系统代码
     "target": "es2016",
     "lib": [
       "es2015",
       "es2016",
       "esnext.asynciterable"
-  ],
+    ],
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
     "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-
-    "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-    "outDir":"./dist",     //重定向输出目录。
-    "experimentalDecorators":true,
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "moduleResolution": "node",
-    "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
   },
-  "include":[
+  "include": [
     "./**/*.ts"
   ],
   "exclude": [

--- a/tools/pinus-cli/tsconfig.json
+++ b/tools/pinus-cli/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
     "noImplicitThis": true,
     "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
 
     "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/tools/pinus-robot/tsconfig.json
+++ b/tools/pinus-robot/tsconfig.json
@@ -19,7 +19,8 @@
     ],
       "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
       "noImplicitThis": true,
-    "inlineSourceMap": true,
+      "inlineSourceMap": true,
+      "newLine": "lf", // 统一跨平台下编译文件的换行符
 
   
       "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。

--- a/tools/pinus-robot/tsconfig.json
+++ b/tools/pinus-robot/tsconfig.json
@@ -1,39 +1,38 @@
 {
-    "compilerOptions": {
-      // types option has been previously configured
-      "types": [
+  "compilerOptions": {
+    // types option has been previously configured
+    "types": [
       // add node as an option
       "node"
-      ],
-      // typeRoots option has been previously configured
-      "typeRoots": [
+    ],
+    // typeRoots option has been previously configured
+    "typeRoots": [
       // add path to @types
       "node_modules/@types"
-      ],
-      "module": "commonjs",   //指定生成哪个模块系统代码
-      "target": "es2016",
-      "lib": [
-        "es2015",
-        "es2016",
-        "esnext.asynciterable"
     ],
-      "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
-      "noImplicitThis": true,
-      "inlineSourceMap": true,
-      "newLine": "lf", // 统一跨平台下编译文件的换行符
+    "module": "commonjs", //指定生成哪个模块系统代码
+    "target": "es2016",
+    "lib": [
+      "es2015",
+      "es2016",
+      "esnext.asynciterable"
+    ],
+    "noImplicitAny": true, //在表达式和声明上有隐含的'any'类型时报错。
+    "noImplicitThis": true,
+    "inlineSourceMap": true,
+    "newLine": "lf", // 统一跨平台下编译文件的换行符
 
-  
-      "rootDirs": ["."],      //仅用来控制输出的目录结构--outDir。
-      "outDir":"./dist",     //重定向输出目录。
-      "experimentalDecorators":true,
-      "emitDecoratorMetadata": true,
-      "moduleResolution": "node",
-      "watch":false            //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
-    },
-    "include":[
-      "./**/*.ts"
-    ],
-    "exclude": [
-      "./dist/**/*.*"
-    ]
-  }
+    "rootDirs": ["."], //仅用来控制输出的目录结构--outDir。
+    "outDir": "./dist", //重定向输出目录。
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "moduleResolution": "node",
+    "watch": false //在监视模式下运行编译器。会监视输出文件，在它们改变时重新编译。
+  },
+  "include": [
+    "./**/*.ts"
+  ],
+  "exclude": [
+    "./dist/**/*.*"
+  ]
+}


### PR DESCRIPTION
如题所述，由于我们团队中有部分人用macos，有部分人用Windows，导致大家编译结果的换行符总是不一致的，所以建议统一一下换行符。这样更规范一些