### PR TITLE
限制pinus-robot的socket.io-client版本

### DIFF
--- a/tools/pinus-robot/package.json
+++ b/tools/pinus-robot/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "cliff": "^0.1.10",
     "socket.io": "^4.1.3",
-    "socket.io-client": "^4.1.3",
+    "socket.io-client": "~4.1.3",
     "typescript": "^4.3.5",
     "underscore": "1.13.1"
   },


### PR DESCRIPTION
pinus-robot的socket.io-client^匹配版本过高，会导致编译报错
![image](https://user-images.githubusercontent.com/21210394/216253975-ce41dbff-d44f-41f9-9dc5-3853a3f316cc.png)