### PR TITLE
增加remote相对路径功能支持，可以让项目打成可执行程序或直接部署到不同服务器的不同路径

### DIFF
--- a/packages/pinus-loader/lib/loader.ts
+++ b/packages/pinus-loader/lib/loader.ts
@@ -124,11 +124,11 @@ export function checkFileType(fn: string, suffix: string) {
 }
 
 let isFile = function (path: string) {
-    return fs.statSync(path, { throwIfNoEntry: false })?.isFile();
+    return fs.existsSync(path) && fs.statSync(path).isFile();
 };
 
 let isDir = function (path: string) {
-    return fs.statSync(path, { throwIfNoEntry: false })?.isDirectory();
+    return fs.existsSync(path) && fs.statSync(path).isDirectory();
 };
 
 let getFileName = function (fp: string, suffixLength: number) {

--- a/packages/pinus-loader/lib/loader.ts
+++ b/packages/pinus-loader/lib/loader.ts
@@ -28,6 +28,11 @@ export function load(mpath: string, context: any, reload: boolean, createInstanc
         throw new Error('opts or opts.path should not be empty.');
     }
 
+    // maybe relative path, need convert to full path
+    if (!isDir(mpath)) {
+        mpath = process.cwd() + mpath;
+    }
+
     try {
         mpath = fs.realpathSync(mpath);
     } catch (err) {
@@ -119,11 +124,11 @@ export function checkFileType(fn: string, suffix: string) {
 }
 
 let isFile = function (path: string) {
-    return fs.statSync(path).isFile();
+    return fs.statSync(path, { throwIfNoEntry: false })?.isFile();
 };
 
 let isDir = function (path: string) {
-    return fs.statSync(path).isDirectory();
+    return fs.statSync(path, { throwIfNoEntry: false })?.isDirectory();
 };
 
 let getFileName = function (fp: string, suffixLength: number) {

--- a/packages/pinus/lib/application.ts
+++ b/packages/pinus/lib/application.ts
@@ -27,7 +27,7 @@ import { BackendSessionService } from './common/service/backendSessionService';
 import { ChannelService, ChannelServiceOptions } from './common/service/channelService';
 import { SessionComponent } from './components/session';
 import { ServerComponent } from './components/server';
-import { RemoteComponent } from './components/remote';
+import { RemoteComponent, RemoteComponentOptions } from './components/remote';
 import { ProxyComponent, RouteFunction, RouteMaps } from './components/proxy';
 import { ProtobufComponent, ProtobufComponentOptions } from './components/protobuf';
 import { MonitorComponent } from './components/monitor';
@@ -649,6 +649,7 @@ export class Application {
     set(setting: 'backendSessionService', val: BackendSessionComponent, attach?: boolean): Application;
     set(setting: 'protobufConfig', val: ProtobufComponentOptions, attach?: boolean): Application;
     set(setting: 'connectorConfig', val: ConnectorComponentOptions, attach?: boolean): Application;
+    set(setting: 'remoteConfig', val: RemoteComponentOptions, attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.BEFORE_FILTER, val: BeforeHandlerFilter[], attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.AFTER_FILTER, val: AfterHandlerFilter[], attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.GLOBAL_BEFORE_FILTER, val: BeforeHandlerFilter[], attach?: boolean): Application;
@@ -682,6 +683,7 @@ export class Application {
     get(setting: 'channelService'): ChannelService;
     get(setting: 'sessionService'): SessionService;
     get(setting: 'channelConfig'): ChannelServiceOptions;
+    get(setting: 'remoteConfig'): RemoteComponentOptions;
     get(setting: 'backendSessionService'): BackendSessionComponent;
     get(setting: Constants.KEYWORDS.BEFORE_FILTER): BeforeHandlerFilter[];
     get(setting: Constants.KEYWORDS.AFTER_FILTER): AfterHandlerFilter[];

--- a/packages/pinus/lib/components/remote.ts
+++ b/packages/pinus/lib/components/remote.ts
@@ -19,7 +19,7 @@ export interface RemoteComponentOptions extends RpcServerOpts {
     rpcDebugLog?: boolean;
     rpcLogger?: Logger;
 
-    rpcServer?: { create: (opts ?: RemoteComponentOptions) => Gateway };
+    rpcServer?: { create: (opts?: RemoteComponentOptions) => Gateway };
 
     /**
      * convert remote path to relative path (need to upgrade pinus-loader to a supported version)
@@ -50,7 +50,7 @@ export class RemoteComponent implements IComponent {
             opts.rpcDebugLog = true;
             opts.rpcLogger = getLogger('rpc-debug', path.basename(__filename));
         }
-        
+
         opts.relativePath = opts.relativePath || false;
         opts.paths = this.getRemotePaths(opts.relativePath);
         opts.context = this.app;

--- a/packages/pinus/lib/components/remote.ts
+++ b/packages/pinus/lib/components/remote.ts
@@ -23,9 +23,8 @@ export interface RemoteComponentOptions extends RpcServerOpts {
 
     /**
      * convert remote path to relative path (need to upgrade pinus-loader to a supported version)
-     * 
      * If you want to deploy the project to different paths on multiple servers,
-     * or use the packaging tool to package and deploy on multiple servers, you can enable this function. 
+     * or use the packaging tool to package and deploy on multiple servers, you can enable this function.
      * each process will have its own running path as the root path
      */
     relativePath?: boolean;

--- a/packages/pinus/lib/util/pathUtil.ts
+++ b/packages/pinus/lib/util/pathUtil.ts
@@ -5,6 +5,16 @@ import { RemoteServerCode } from '../index';
 import { DIR } from './constants';
 
 /**
+ * Get relative path
+ *
+ * @param  {String} path full path
+ * @return {String} relative path
+ */
+export function getRelativePath(path) {
+    return path.replace(process.cwd(), '')
+}
+
+/**
  * Get system remote service path
  *
  * @param  {String} role server role: frontend, backend
@@ -64,9 +74,13 @@ export function listUserRemoteDir(appBase: string) {
  * @param  {String} namespace  remote path namespace, such as: 'sys', 'user'
  * @param  {String} serverType
  * @param  {String} path       remote service source path
+ * @param  {Boolean} relativePath       convert path to relative path
  * @return {Object}            remote path record
  */
-export function remotePathRecord(namespace: string, serverType: string, path: string): RemoteServerCode {
+export function remotePathRecord(namespace: string, serverType: string, path: string, relativePath?: boolean): RemoteServerCode {
+    if (relativePath) {
+        path = getRelativePath(path);
+    }
     return { namespace: namespace, serverType: serverType, path: path };
 }
 

--- a/packages/pinus/lib/util/pathUtil.ts
+++ b/packages/pinus/lib/util/pathUtil.ts
@@ -10,7 +10,7 @@ import { DIR } from './constants';
  * @param  {String} path full path
  * @return {String} relative path
  */
-export function getRelativePath(path) {
+export function getRelativePath(path: string) {
     return path.replace(process.cwd(), '')
 }
 


### PR DESCRIPTION
在不使用自带的ssh进行多服务器项目管理的情况下，感觉还是一个挺有必要的功能
举个例子：
    一个多服项目，使用同一个master进行管理，如果A服务器运行1服，2服，因为配置或者服与服之间功能可能有些许不一样，会分为多个分支进行管理，这样拉取到服务器的路径是不一样的，这时如果增加了B服务器，需要运行3服，那么B服务器就必须也拉取1服，2服的项目到相同路径，否则3服再生成rpc时就会找不到路径，非常不方便！