### PR TITLE
修复typescript 5.x编译错误

### DIFF
--- a/packages/pinus-rpc/lib/rpc-server/server.ts
+++ b/packages/pinus-rpc/lib/rpc-server/server.ts
@@ -38,7 +38,7 @@ let createNamespace = function (namespace: string, proxies: Services) {
  */
 
 export function createServer(opts: Gateway.RpcServerOpts) {
-    if (!opts || !opts.port || opts.port < 0 || !opts.paths) {
+    if (!opts || !opts.port || +opts.port < 0 || !opts.paths) {
         throw new Error('opts.port or opts.paths invalid.');
     }
     opts.services = loadRemoteServices(opts.paths, opts.context, opts.services);


### PR DESCRIPTION
opts.port为number|string类型，直接判断opts.port < 0会导致编译报错