### PR TITLE
为了服务器健壮性，保证monitorAgent始终会进行健康及重连处理

### DIFF
--- a/packages/pinus-admin/lib/consoleService.ts
+++ b/packages/pinus-admin/lib/consoleService.ts
@@ -1,5 +1,5 @@
 import { getLogger } from 'pinus-logger';
-import {MonitorAgent} from './monitor/monitorAgent';
+import { IMonitorAgentClientFactory, MonitorAgent } from './monitor/monitorAgent';
 import { EventEmitter } from 'events';
 import { MasterAgent, MasterAgentOptions } from './master/masterAgent';
 import * as schedule from 'pinus-scheduler';
@@ -66,6 +66,7 @@ export interface MonitorConsoleServiceOpts {
     port?: number;
     env?: string;
     authServer ?: typeof utils.defaultAuthServerMaster;
+    monitorAgentClientFactory?: IMonitorAgentClientFactory;
 }
 
 export type ConsoleServiceOpts = MasterConsoleServiceOpts | MonitorConsoleServiceOpts;
@@ -136,7 +137,8 @@ export class ConsoleService extends EventEmitter {
                 consoleService: this,
                 id: this.id,
                 type: this.type,
-                info: monitorOpts.info
+                info: monitorOpts.info,
+                monitorAgentClientFactory: monitorOpts.monitorAgentClientFactory
             });
         }
     }
@@ -540,8 +542,8 @@ let aclControl = function (agent: MasterAgent, action: string, method: string, m
  * @param {Object} opts construct parameter
  *                      opts.port {String | Number} listen port for master console
  */
-export function createMasterConsole(opts: ConsoleServiceOpts) {
-    (opts as MasterConsoleServiceOpts).master = true;
+export function createMasterConsole(opts: MasterConsoleServiceOpts) {
+    opts.master = true;
     return new ConsoleService(opts);
 }
 
@@ -554,6 +556,6 @@ export function createMasterConsole(opts: ConsoleServiceOpts) {
  *                      opts.host {String} master server host
  *                      opts.port {String | Number} master port
  */
-export function createMonitorConsole(opts: ConsoleServiceOpts) {
+export function createMonitorConsole(opts: MonitorConsoleServiceOpts) {
     return new ConsoleService(opts);
 }

--- a/packages/pinus-admin/lib/protocol/mqtt/robustMqttClient.ts
+++ b/packages/pinus-admin/lib/protocol/mqtt/robustMqttClient.ts
@@ -1,0 +1,67 @@
+/**
+ * 更健壮的MQTT客户端，除非主动调用disconnect，否则会始终保持与server的连接
+ * 情况1：
+ *   master必须第一个启动，才能启动其它服务器进程，否则会启动失败。调整后，不需要必须先启动master，其它进程如果先启动了，会等待master启动后再向master注册
+ * 情况2：
+ *  由于master上会注册所有服务器进程，在重启master的过程中发现有概率出现心跳超时直接就断开monitorAgent与masterAgent的连接，不会重连。
+ *  断开后会导致其它进程向master注册或者移除无法通知到连接断开的服务器，需要自己排查进程是不是断开了，手动重启断开的进程才能重新连接masterAgent
+ */
+import { getLogger } from 'pinus-logger';
+import * as path from 'path';
+import { MqttClient } from './mqttClient';
+let logger = getLogger('pinus-admin', path.basename(__filename));
+
+export class RobustMqttClient extends MqttClient {
+    
+    connect(host ?: string, port ?: number, cb ?: Function) {
+        super.connect(host, port, cb);
+
+        let self = this;
+        // 移除父类监听，使用新的超时机制
+        this.socket.removeAllListeners('timeout');
+        this.socket.on('timeout', function () {
+            self.onSocketClose();
+        });
+    }
+
+    onSocketClose() {
+        // console.log('onSocketClose ' + this.closed);
+        if (this.closed) {
+            return;
+        }
+        this.disconnect();
+        this.reconnect();
+    }
+
+    checkKeepAlive() {
+        if (this.closed) {
+            return;
+        }
+
+        let now = Date.now();
+        let KEEP_ALIVE_TIMEOUT = this.keepalive * 2;
+        if (this.lastPong < this.lastPing && now - this.lastPing > KEEP_ALIVE_TIMEOUT) {
+            logger.error('mqtt rpc client checkKeepAlive error timeout for %d', KEEP_ALIVE_TIMEOUT);
+            this.onSocketClose();
+        } else {
+            this.socket.pingreq();
+            this.lastPing = Date.now();
+        }
+    }
+
+    disconnect() {
+        this.connected = false;
+        this.closed = true;
+        // 取消定时
+        clearInterval(this.keepaliveTimer);
+        clearTimeout(this.timeoutId);
+        clearTimeout(this.reconnectId);
+        // 重置
+        this.lastPing = -1;
+        this.lastPong = -1;
+        // 释放连接
+        this.socket?.disconnect();
+        delete this.socket;
+        this.socket = null;
+    }
+}

--- a/packages/pinus-rpc/lib/rpc-client/mailboxes/mqtt2-mailbox.ts
+++ b/packages/pinus-rpc/lib/rpc-client/mailboxes/mqtt2-mailbox.ts
@@ -218,21 +218,13 @@ export class MQTT2MailBox extends EventEmitter {
     // console.log('checkKeepAlive lastPing %d lastPong %d ~~~', this.lastPing, this.lastPong);
     let now = Date.now();
     let KEEP_ALIVE_TIMEOUT = this.keepalive * 2;
-    if (this.lastPing > 0) {
-      if (this.lastPong < this.lastPing) {
-        if (now - this.lastPing > KEEP_ALIVE_TIMEOUT) {
-          logger.error('mqtt rpc client %s checkKeepAlive timeout from remote server %s for %d lastPing: %s lastPong: %s', this.serverId, this.id, KEEP_ALIVE_TIMEOUT, this.lastPing, this.lastPong);
-          this.emit('close', this.id);
-          this.lastPing = -1;
-          // this.close();
-        }
-      } else {
+    if (this.lastPong < this.lastPing && now - this.lastPing > KEEP_ALIVE_TIMEOUT) {
+        logger.error('mqtt rpc client %s checkKeepAlive timeout from remote server %s for %d lastPing: %s lastPong: %s', this.serverId, this.id, KEEP_ALIVE_TIMEOUT, this.lastPing, this.lastPong);
+        this.emit('close', this.id);
+        this.lastPing = -1;
+    } else {
         this.socket.pingreq();
         this.lastPing = Date.now();
-      }
-    } else {
-      this.socket.pingreq();
-      this.lastPing = Date.now();
     }
   }
 

--- a/packages/pinus/lib/application.ts
+++ b/packages/pinus/lib/application.ts
@@ -45,7 +45,7 @@ import { ModuleRecord } from './util/moduleUtil';
 import { ApplicationEventContructor, IPlugin } from './interfaces/IPlugin';
 import { Cron, ResponseErrorHandler } from './server/server';
 import { RemoterProxy } from './util/remoterHelper';
-import { FrontendOrBackendSession, ISession, ScheduleOptions, SID, UID } from './index';
+import { FrontendOrBackendSession, ISession, MonitorOptions, ScheduleOptions, SID, UID } from './index';
 
 let logger = getLogger('pinus', path.basename(__filename));
 
@@ -650,6 +650,7 @@ export class Application {
     set(setting: 'protobufConfig', val: ProtobufComponentOptions, attach?: boolean): Application;
     set(setting: 'connectorConfig', val: ConnectorComponentOptions, attach?: boolean): Application;
     set(setting: 'remoteConfig', val: RemoteComponentOptions, attach?: boolean): Application;
+    set(setting: 'monitorConfig', val: MonitorOptions, attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.BEFORE_FILTER, val: BeforeHandlerFilter[], attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.AFTER_FILTER, val: AfterHandlerFilter[], attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.GLOBAL_BEFORE_FILTER, val: BeforeHandlerFilter[], attach?: boolean): Application;


### PR DESCRIPTION
情况1：
    其它服务器进程启动顺序比master快，会直接process.exit()，导致进程无法启动。调整后，会等待master启动后再向master注册，不需要必须先启动master，再启动其它进程
情况2：
![image](https://user-images.githubusercontent.com/21210394/234768444-03681dad-c3f5-4eb6-aeaa-b31c7cfedddc.png)
    由于master上会注册所有服务器进程，在重启master的过程中发现有概率出现心跳超时直接就断开monitorAgent与masterAgent的连接，不会重连。断开后会导致其它进程向master注册或者移除无法通知到连接断开的服务器，需要自己一个一个进程去看是不是断开了，如果断开了，需要手动重启才能重新连接masterAgent

monitorAgent的连接与rpc不同，rpc断开后，如果下次触发rpc会再次建立连接。monitorAgent的断开了就需要自己手动重启相应进程，服务器进程很多，需要一个一个排查非常麻烦。出于服务器健壮性的考虑，与master的连接无论何种情况下都不应该存在断开不管了，除非主动调用了consoleService的stop

mqtt2-mailbox也存在与mqtt-mailbox一样的连接断开问题，不知道mqtt2-mailbox实际有没有启用，顺带修复了