### PR TITLE
rpc模块增加父类方法路由支持

### DIFF
--- a/packages/pinus-rpc/lib/rpc-client/client.ts
+++ b/packages/pinus-rpc/lib/rpc-client/client.ts
@@ -145,6 +145,9 @@ export interface RpcClientOpts extends MailStationOpts {
 
      */
     dynamicUserProxy?: boolean;
+
+    // 默认路由生成不包含父类方法，导致本来可以在remote父类声明的方法只能在每个remote都写一份
+    containParentMethod?: boolean;
 }
 
 export interface RpcMsg {
@@ -545,7 +548,7 @@ export class RpcClient {
     private genObjectProxy(serviceName: string, origin: any, attach: RemoteServerCode) {
         // generate proxy for function field
         let res: { [key: string]: Proxy } = {};
-        let proto = listEs6ClassMethods(origin);
+        let proto = listEs6ClassMethods(origin, this.opts.containParentMethod);
         for (let field of proto) {
             res[field] = this.genFunctionProxy(serviceName, field, origin, attach);
         }

--- a/packages/pinus-rpc/lib/util/utils.ts
+++ b/packages/pinus-rpc/lib/util/utils.ts
@@ -221,12 +221,13 @@ export let getBearcat = function () {
 };
 
 /**
- * 列出ES6的一个Class实例上的所有方法，但不包括父类的
+ * 列出ES6的一个Class实例上的所有方法
  * @param objInstance
+ * @param containParent ture 包含父类方法 默认不包含
  */
-export function listEs6ClassMethods(objInstance: { [key: string]: any }) {
+export function listEs6ClassMethods(objInstance: { [key: string]: any }, containParent?: boolean) {
+    let names: string[] = [];
     if (objInstance.prototype && objInstance.prototype.constructor === objInstance) {
-        let names: string[] = [];
         let methodNames = Object.getOwnPropertyNames(objInstance.prototype);
         for (let name of methodNames) {
             let method = objInstance.prototype[name];
@@ -234,16 +235,27 @@ export function listEs6ClassMethods(objInstance: { [key: string]: any }) {
             if (!(method instanceof Function) || name === 'constructor') continue;
             names.push(name);
         }
-        return names;
-    } else {
-        let names: string[] = [];
-        let methodNames = Object.getOwnPropertyNames(Object.getPrototypeOf(objInstance)).concat(Object.getOwnPropertyNames(objInstance));
-        for (let name of methodNames) {
-            let method = objInstance[name];
-            // Supposedly you'd like to skip constructor
-            if (!(method instanceof Function) || name === 'constructor') continue;
-            names.push(name);
-        }
-        return names;
     }
+    // 包含父类方法
+    else {
+        let methodNames = Object.getOwnPropertyNames(objInstance);
+        let instance = Object.getPrototypeOf(objInstance);
+        while (instance) {
+            methodNames.push(...Object.getOwnPropertyNames(instance));
+            instance = Object.getPrototypeOf(instance);
+
+            // 所有对象最底层都继承于Object，跳过Object对象的方法收集
+            if (!containParent || instance['constructor']?.name === Object.name) {
+                break;
+            }
+        }
+        for (let name of methodNames) {
+            // Supposedly you'd like to skip constructor
+            if (name !== 'constructor' && objInstance[name] instanceof Function) {
+                names.push(name);
+            }
+        }
+    }
+
+    return names;
 }

--- a/packages/pinus/lib/application.ts
+++ b/packages/pinus/lib/application.ts
@@ -28,7 +28,7 @@ import { ChannelService, ChannelServiceOptions } from './common/service/channelS
 import { SessionComponent } from './components/session';
 import { ServerComponent } from './components/server';
 import { RemoteComponent, RemoteComponentOptions } from './components/remote';
-import { ProxyComponent, RouteFunction, RouteMaps } from './components/proxy';
+import { ProxyComponent, ProxyComponentOptions, RouteFunction, RouteMaps } from './components/proxy';
 import { ProtobufComponent, ProtobufComponentOptions } from './components/protobuf';
 import { MonitorComponent } from './components/monitor';
 import { MasterComponent } from './components/master';
@@ -651,6 +651,7 @@ export class Application {
     set(setting: 'connectorConfig', val: ConnectorComponentOptions, attach?: boolean): Application;
     set(setting: 'remoteConfig', val: RemoteComponentOptions, attach?: boolean): Application;
     set(setting: 'monitorConfig', val: MonitorOptions, attach?: boolean): Application;
+    set(setting: 'proxyConfig', val: ProxyComponentOptions, attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.BEFORE_FILTER, val: BeforeHandlerFilter[], attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.AFTER_FILTER, val: AfterHandlerFilter[], attach?: boolean): Application;
     set(setting: Constants.KEYWORDS.GLOBAL_BEFORE_FILTER, val: BeforeHandlerFilter[], attach?: boolean): Application;


### PR DESCRIPTION
原本底层rpc路由生成不支持父类方法，局限性比较大
举个例子：
    服务器出于数据库性能考虑，增加了进程级内存缓存，如果数据发生变化，则需要通知其它进程进行内存缓存清理操作，以便于其它进程下次真的需要这个数据时，可以从数据库获取最新数据。这样需要清理缓存的进程都需要在remote实现清理方法，如果可以路由父类方法，则继承同一个父类即可，而不需要每个remote单独实现清理方法

```
app.set('proxyConfig', {
    containParentMethod: true // 开启父类方法路由支持
});
```