### PR TITLE
Fix potential crash by adding null check for proto options

### DIFF
--- a/packages/pinus-protobuf/lib/decoder.ts
+++ b/packages/pinus-protobuf/lib/decoder.ts
@@ -48,7 +48,7 @@ export class Decoder {
             let tag = head.tag;
             let name = protos.__tags[tag];
 
-            switch (protos[name].option) {
+            switch (protos[name]?.option) {
                 case 'optional':
                 case 'required':
                     msg[name] = this.decodeProp(protos[name].type, protos);


### PR DESCRIPTION
Added a null-safe operator to prevent accessing undefined properties in the decoder. This ensures stability when processing unexpected or incomplete protobuf structures.