### PR TITLE
Update Express middleware and dependencies in web server templates

### DIFF
--- a/examples/simple-example/web-server/app.js
+++ b/examples/simple-example/web-server/app.js
@@ -1,9 +1,11 @@
 var express = require('express');
+var methodOverride = require('method-override');
+var bodyParser = require('body-parser');
 var app = express();
 
-  app.use(express.methodOverride());
-  app.use(express.bodyParser());
-  app.use(app.router);
+  app.use(methodOverride());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
   app.set('view engine', 'jade');
   app.set('views', __dirname + '/public');
   app.set('view options', {layout: false});

--- a/examples/simple-example/web-server/package.json
+++ b/examples/simple-example/web-server/package.json
@@ -3,6 +3,8 @@
   "version": "1.7.3",
   "private": false,
   "dependencies": {
-    "express": "4.19.2"
+    "body-parser": "^1.20.3",
+    "express": "4.19.2",
+    "method-override": "^3.0.0"
   }
 }

--- a/examples/ssl-connector/web-server/app.js
+++ b/examples/ssl-connector/web-server/app.js
@@ -1,9 +1,11 @@
 var express = require('express');
+var methodOverride = require('method-override');
+var bodyParser = require('body-parser');
 var app = express();
 
-  app.use(express.methodOverride());
-  app.use(express.bodyParser());
-  app.use(app.router);
+  app.use(methodOverride());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
   app.set('view engine', 'jade');
   app.set('views', __dirname + '/public');
   app.set('view options', {layout: false});

--- a/examples/ssl-connector/web-server/package.json
+++ b/examples/ssl-connector/web-server/package.json
@@ -3,6 +3,8 @@
   "version": "1.7.3",
   "private": true,
   "dependencies": {
-    "express": "4.19.2"
+    "body-parser": "^1.20.3",
+    "express": "4.19.2",
+    "method-override": "^3.0.0"
   }
 }

--- a/examples/websocket-chat/web-server/app.js
+++ b/examples/websocket-chat/web-server/app.js
@@ -1,9 +1,11 @@
 var express = require('express');
+var methodOverride = require('method-override');
+var bodyParser = require('body-parser');
 var app = express();
 
-  app.use(express.methodOverride());
-  app.use(express.bodyParser());
-  app.use(app.router);
+  app.use(methodOverride());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
   app.set('view engine', 'jade');
   app.set('views', __dirname + '/public');
   app.set('view options', {layout: false});

--- a/examples/websocket-chat/web-server/package.json
+++ b/examples/websocket-chat/web-server/package.json
@@ -3,6 +3,8 @@
 	"version": "1.7.3",
 	"private": false,
 	"dependencies": {
-		"express": "4.19.2"
+		"body-parser": "^1.20.3",
+		"express": "4.19.2",
+		"method-override": "^3.0.0"
 	}
 }

--- a/packages/pinus/template/web-server/app.js
+++ b/packages/pinus/template/web-server/app.js
@@ -1,9 +1,11 @@
 var express = require('express');
+var methodOverride = require('method-override');
+var bodyParser = require('body-parser');
 var app = express();
 
-  app.use(express.methodOverride());
-  app.use(express.bodyParser());
-  app.use(app.router);
+  app.use(methodOverride());
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: true }));
   app.set('view engine', 'jade');
   app.set('views', __dirname + '/public');
   app.set('view options', {layout: false});

--- a/packages/pinus/template/web-server/package.json
+++ b/packages/pinus/template/web-server/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.1",
   "private": false,
   "dependencies": {
-    "express": "4.19.2"
+    "body-parser": "^1.20.3",
+    "express": "4.19.2",
+    "method-override": "^3.0.0"
   }
 }


### PR DESCRIPTION
Replace deprecated Express middleware with body-parser and method-override in multiple web server templates across different examples and the project template

更新 Web 服务器模板中的 Express 中间件和依赖项。

在不同示例和项目模板中的多个 Web 服务器模板中，用 body-parser 和 method-override 替换已弃用的 Express 中间件。

https://github.com/senchalabs/connect#middleware